### PR TITLE
fix: disable default utf-8 encoding for image copying in gulp

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -128,7 +128,7 @@ gulp.task('clean', gulp.parallel(
 
 // copy copies the built artifacts in build into dist/
 gulp.task('copy:codelabs', () => {
-  return gulp.src(CODELABS_BUILD_DIR + '/**')
+  return gulp.src(CODELABS_BUILD_DIR + '/**', { encoding: false })
     .pipe(gulp.dest('build/' + CODELABS_NAMESPACE))
     .pipe(livereload());
 })


### PR DESCRIPTION
Fixes #1 

This took some time to trace to the root cause. Once I identified Gulp file copying as the issue due to the images being corrupted when being moved from the `site/viamguides/dist` directory to the `site/viamguides/build/guide` directory, I was able to search for related issues on the web. [This StackOverflow answer](https://stackoverflow.com/questions/78391263/copying-images-with-gulp-are-corrupted-damaged) resolved this exact problem that came from the Gulp 5 release earlier this year. 

Once the default UTF-8 encoding was disabled, the images showed up as expected when running the site locally:

![image](https://github.com/user-attachments/assets/990dcd9c-dc23-40f1-b1a5-f3ec3c8a0634)
