### PR TITLE
fix(build): use ordered-read-stream, include java in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 
 jobs:
@@ -32,7 +31,7 @@ jobs:
       - name: Install project deps and build
         run: |
           cd site
-          npm install
+          npm ci
           npm run build
 
       - name: Include CNAME file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install project deps and build
         run: |
           cd site
-          npm ci
+          npm install
           npm run build
 
       - name: Include CNAME file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
             [tools]
             node = "20"
             go = "latest"
+            java = "latest"
 
       - name: Install claat
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Install global env tools
         uses: jdx/mise-action@v2
         with:
-          experimental: true
           mise_toml: |
             [tools]
             node = "20"
@@ -28,8 +27,15 @@ jobs:
         run: |
           go install github.com/googlecodelabs/tools/claat@latest
 
+      - name: Check JAVA_HOME
+        shell: bash
+        run: |
+          echo $JAVA_HOME
+
       - name: Install project deps and build
+        shell: bash
         run: |
           cd site
           npm install
+          npm install google-closure-compiler-java google-closure-compiler-linux
           npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
             [tools]
             node = "20"
             go = "latest"
+            java = "latest"
 
       - name: Install claat
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,9 @@ jobs:
         run: |
           go install github.com/googlecodelabs/tools/claat@latest
 
-      - name: Check JAVA_HOME
-        shell: bash
-        run: |
-          echo $JAVA_HOME
-
       - name: Install project deps and build
         shell: bash
         run: |
           cd site
-          npm install
-          npm install google-closure-compiler-java google-closure-compiler-linux
+          npm ci
           npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Install project deps and build
         run: |
           cd site
-          npm ci
+          npm install
           npm run build

--- a/site/app/js/claat/ui/cards/cardsorter.js
+++ b/site/app/js/claat/ui/cards/cardsorter.js
@@ -347,3 +347,12 @@ function intersect(a, b) {
   }
   return false;
 }
+
+/**
+* @type {{
+*  require: Function,
+*  provide: Function,
+*  module: Function,
+* }}
+*/
+var goog;

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -8,7 +8,7 @@ const closureCompilerPackage = require('google-closure-compiler');
 const closureCompiler = closureCompilerPackage.gulp();
 const crisper = require('gulp-crisper');
 const gulpif = require('gulp-if');
-const merge = require('merge-stream');
+const merge = require('ordered-read-streams');
 const lightningcss = require('gulp-lightningcss');
 const sass = require('gulp-sass')(require('sass'));
 const swc = require('gulp-swc');
@@ -224,7 +224,7 @@ gulp.task('build:js', (callback) => {
       'app/js/claat/ui/cards/cardsorter_export.js',
     ];
     streams.push(gulp.src(cardSorterSrcs, { base: 'app/' })
-      .pipe(closureCompiler(opts.closureCompiler(), { platform: 'javascript' }))
+      .pipe(closureCompiler(opts.closureCompiler(), { platform: ['native', 'java'] }))
       .pipe(swc(opts.swc()))
       .pipe(gulp.dest('app/js/bundle'))
     );

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -20,6 +20,7 @@
         "fs-extra": "^7.0.1",
         "glob": "^7.2.0",
         "google-closure-compiler": "^20240317.0.0",
+        "google-closure-compiler-java": "^20240317.0.0",
         "gulp-babel": "^8.0.0",
         "gulp-crisper": "^1.1.0",
         "gulp-flatten": "^0.4.0",
@@ -50,6 +51,9 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "optionalDependencies": {
+        "google-closure-compiler-linux": "^20240317.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5610,7 +5614,6 @@
         "x32",
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -40,7 +40,7 @@
         "jscs": "^1.13.1",
         "jshint": "^2.13.4",
         "jshint-stylish": "^2.2.1",
-        "merge-stream": "^1.0.1",
+        "ordered-read-streams": "^2.0.0",
         "path": "^0.12.7",
         "sass": "^1.49.11",
         "swig-templates": "^2.0.3",
@@ -6714,6 +6714,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/gulp-useref/node_modules/ordered-read-streams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+      "integrity": "sha512-Z87aSjx3r5c0ZB7bcJqIgIRX5bxR7A4aSzvIbaxd0oTkWBCOoKfuGHiKj60CHVUgg1Phm5yMZzBdt8XqRs73Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.1"
+      }
+    },
     "node_modules/gulp-useref/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -10887,42 +10897,16 @@
       "dev": true
     },
     "node_modules/ordered-read-streams": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-      "integrity": "sha512-Z87aSjx3r5c0ZB7bcJqIgIRX5bxR7A4aSzvIbaxd0oTkWBCOoKfuGHiKj60CHVUgg1Phm5yMZzBdt8XqRs73Mw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-2.0.0.tgz",
+      "integrity": "sha512-YT9wHHV9mB/qadhWnBsC57JKhAMA22/aR+RwZRgcf4K4Q7IIfmSsnYGxgiu9LVZP3wddRAm5pfYkzkmBb+HuwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/ordered-read-streams/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/ordered-read-streams/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/ordered-read-streams/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "streamx": "^2.12.5"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/p-map": {

--- a/site/package.json
+++ b/site/package.json
@@ -38,7 +38,7 @@
     "jscs": "^1.13.1",
     "jshint": "^2.13.4",
     "jshint-stylish": "^2.2.1",
-    "merge-stream": "^1.0.1",
+    "ordered-read-streams": "^2.0.0",
     "path": "^0.12.7",
     "sass": "^1.49.11",
     "swig-templates": "^2.0.3",

--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,9 @@
     "template": "./init.sh",
     "clean": "gulp clean"
   },
+  "optionalDependencies": {
+    "google-closure-compiler-linux": "^20240317.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.24.9",
     "@babel/preset-env": "^7.24.8",
@@ -18,6 +21,7 @@
     "fs-extra": "^7.0.1",
     "glob": "^7.2.0",
     "google-closure-compiler": "^20240317.0.0",
+    "google-closure-compiler-java": "^20240317.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-crisper": "^1.1.0",
     "gulp-flatten": "^0.4.0",


### PR DESCRIPTION
After merging #13, the CI build failed due to issues with the google-closure-compiler and the latest version of Gulp.

One issue was resolved by included Java in the CI tools so that version of the closure-compiler was used instead of the native build used locally. Also, including a global variable for `goog` to resolve the `goog.provide` calls in the relevant files, correctly. 

The second issue was resolved by replacing the `merge-streams` package, which is incompatible with Gulp 5, with `ordered-read-streams` package as identified by this comment: https://github.com/gulpjs/gulp/issues/2802#issuecomment-2255377128

